### PR TITLE
Fix unit conversion code. = instead of ==

### DIFF
--- a/gpsdeasy.py
+++ b/gpsdeasy.py
@@ -462,9 +462,9 @@ class Gpsdeasy(plugins.Plugin):
                 try:
                     if 'speed' in coords:
                         if self.speedUnit == 'kph':
-                            coords['speed'] == coords['speed'] * 3.6
+                            coords['speed'] = coords['speed'] * 3.6
                         elif self.speedUnit == 'mph':
-                            coords['speed'] == coords['speed'] * 2.237
+                            coords['speed'] = coords['speed'] * 2.237
                         else:
                             coords['speed']
                         


### PR DESCRIPTION
The conversion to km/h or mph was using a comparison operator (==) instead of the assignment operator (=), so the speed was always displaying the default GPSD value (meters per second, I think), not actually converting.